### PR TITLE
[Fix/#46] 홈화면 product 컬렉션뷰 사이즈 및 레이아웃 문제 해결

### DIFF
--- a/Daangn_iOS/Daangn_iOS/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/Daangn_iOS/Daangn_iOS/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -63,10 +63,12 @@ final class HomeViewController: UIViewController {
         setButtonAction()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         
-        fetchProducts()
+        productCollectionView.invalidateIntrinsicContentSize()
+        scrollView.invalidateIntrinsicContentSize()
+        view.layoutIfNeeded()
     }
     
     // MARK: - Layout
@@ -387,6 +389,7 @@ extension HomeViewController: ApplyFiltersToHomeDelegate {
         categories = selectedCategories
         categoryCollectionView.reloadData()
         updateCategoryCollectionViewHeight()
+        fetchProducts()
     }
 }
 


### PR DESCRIPTION
## 🍽️ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- ✅상품 컬렉션뷰 및 스크롤뷰 contentSize대로 안 나오는 문제 해결
- ✅ fetchProducts() 함수를 viewDidLoad, viewWillAppear 두곳에서 모두 호출할 때만 상품 컬렉션뷰가 잘 나타나는 문제 해결
- (아직 해결 ❌) 카테고리 필터 삭제하다가 가끔 스크롤 안 되는 문제...

## 🚗 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- viewDidLayoutSubviews() 하위뷰의 레이아웃을 잡은 후,
- 상품 컬렉션뷰, 상위 스크롤뷰의사이즈를 재계산 후 전체 뷰 레이아웃을 다시 잡아주는 코드를 추가하였습니다.
- 따라서 기존에 viewWillAppear()에 써주었던 fetchProducts() 코드를 삭제해도 정상적으로 홈화면에 상품이 잘 나타납니다.
- 추가로, 카테고리 필터 삭제 및 상세필터화면에서 적용하기 버튼 눌렀을 때 (Delegate 패턴 함수에서) 일관적으로 fetchProducts() 코드를 추가해주었습니다.
```
override func viewDidLayoutSubviews() {
    super.viewDidLayoutSubviews()
     
    productCollectionView.invalidateIntrinsicContentSize()
    scrollView.invalidateIntrinsicContentSize()
    view.layoutIfNeeded()
}
```

## 📱 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 상품 컬렉션뷰 사이즈, 레이아웃 정확하게 잘 나오는 중 | <img src = "https://github.com/user-attachments/assets/6048b08d-2b75-4d50-aef3-738606324a55" width = 300> |
| 😅 카테고리 필터 삭제하다가 가끔 스크롤이 안 되는 경우 | <img src = "https://github.com/user-attachments/assets/57103126-535d-4712-b862-5b7da76d6248" width = 300> |


## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- 코드 컨벤션 확인!

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #46
